### PR TITLE
Renaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ dist
 # Project files & folders
 testflow
 .checkpoint
+Decoded

--- a/src/workflow/metadata.js
+++ b/src/workflow/metadata.js
@@ -126,9 +126,14 @@ let setMetadataInBatch = async (
   await signAndSendTx(api, call, signingPair, true, dryRun);
 };
 
-let setClassMetadata = async (connection, classId, metadataCid, dryRun) => {
+let setCollectionMetadata = async (
+  connection,
+  classId,
+  metadataCid,
+  dryRun
+) => {
   const { api, signingPair, proxiedAddress } = connection;
-  let tx = api.tx.uniques.setClassMetadata(classId, metadataCid, false);
+  let tx = api.tx.uniques.setCollectionMetadata(classId, metadataCid, false);
 
   let txCall = proxiedAddress
     ? api.tx.proxy.proxy(proxiedAddress, 'Assets', tx)
@@ -137,7 +142,7 @@ let setClassMetadata = async (connection, classId, metadataCid, dryRun) => {
   await signAndSendTx(api, txCall, signingPair, true, dryRun);
 };
 
-const generateAndSetClassMetadata = async (
+const generateAndSetCollectionMetadata = async (
   connection,
   pinataClient,
   classId,
@@ -154,13 +159,13 @@ const generateAndSetClassMetadata = async (
     outputFile
   );
 
-  await setClassMetadata(connection, classId, metaCid);
+  await setCollectionMetadata(connection, classId, metaCid);
 
   return metaCid;
 };
 
 module.exports = {
-  generateAndSetClassMetadata,
+  generateAndSetCollectionMetadata,
   setMetadataInBatch,
   generateMetadata,
 };

--- a/src/workflow/workflow.js
+++ b/src/workflow/workflow.js
@@ -62,7 +62,7 @@ const createClass = async (wfConfig) => {
         );
       } else {
         context.class.id = cfgClassId;
-        context.class.startInstanceId = Number(uniquesClass?.instances);
+        context.class.startInstanceId = Number(uniquesClass?.items);
         // set the start instance id to the last id available in the class assuming all instances are minted from 0 to number of current instances.
         console.log(
           systemMessage(

--- a/src/workflow/workflow.js
+++ b/src/workflow/workflow.js
@@ -4,7 +4,7 @@ const path = require('path');
 const BN = require('bn.js');
 
 const {
-  generateAndSetClassMetadata,
+  generateAndSetCollectionMetadata,
   generateMetadata,
   setMetadataInBatch,
 } = require('./metadata');
@@ -88,7 +88,7 @@ const createClass = async (wfConfig) => {
   }
 };
 
-const setClassMetadata = async (wfConfig) => {
+const setCollectionMetadata = async (wfConfig) => {
   // 2-generate/set class metadata
   const context = getContext();
   const { dryRun } = context;
@@ -120,7 +120,7 @@ const setClassMetadata = async (wfConfig) => {
     } else {
       let metadataFolder = wfConfig.metadataFolder;
       let metadataFile = path.join(metadataFolder, 'class.meta');
-      context.class.metaCid = await generateAndSetClassMetadata(
+      context.class.metaCid = await generateAndSetCollectionMetadata(
         context.network,
         context.pinataClient,
         context.class.id,
@@ -644,7 +644,7 @@ const runWorkflow = async (configFile = './src/workflow.json', dryRunMode) => {
 
   // 2- set classMetadata
   console.info(stepTitle`\n\nSetting class metadata ...`);
-  await setClassMetadata(config);
+  await setCollectionMetadata(config);
 
   // 3- generate secrets
   console.info(stepTitle`\n\nGenerating gift secrets ...`);
@@ -717,7 +717,7 @@ const updateMetadata = async (
 
   // 2- set classMetadata
   console.info(stepTitle`\n\nSetting class metadata ...`);
-  await setClassMetadata(config);
+  await setCollectionMetadata(config);
 
   //3- pin images and generate metadata
   console.info(stepTitle`\n\nUploading and pinning the NFTs on IPFS ...`);


### PR DESCRIPTION
As of [cumulus v0.9.230](https://github.com/paritytech/cumulus/releases/tag/v0.9.230) the following renaming in the exterinsics/types are applied to unique pallet:
- instance -> item
- class -> collection
The storage items are not renamed to keep backward compatibility
more context:
[substrate PR 11389](https://github.com/paritytech/substrate/pull/11389)